### PR TITLE
fix Unpacker.guess

### DIFF
--- a/sflock/abstracts.py
+++ b/sflock/abstracts.py
@@ -70,9 +70,6 @@ class Unpacker(object):
         return not return_code
 
     def handles(self):
-        if self.f.filename and self.f.filename.lower().endswith(self.exts):
-            return True
-
         if self.f.package and self.f.package in make_list(self.package or []):
             return True
 


### PR DESCRIPTION
Remove the extension check as it would return NSIS for regular PE files because of list order. Rely on package or magic instead.